### PR TITLE
fix conda pkg name in yaml so it builds

### DIFF
--- a/configs/conda/short-read-taxonomy.yaml
+++ b/configs/conda/short-read-taxonomy.yaml
@@ -32,7 +32,7 @@ dependencies:
   - cffi=1.15.1=py37h43b0acd_0
   - charset-normalizer=2.1.0=pyhd8ed1ab_0
   - click=8.1.3=py37h89c1867_0
-  - click_default_group
+  - click-default-group
   - cmseq=1.0.4=pyhb7b1952_0
   - cryptography=37.0.4=py37h38fbfac_0
   - cycler=0.11.0=pyhd8ed1ab_0


### PR DESCRIPTION
click-default-group with dashes not underscores solved issue detailed below (easy to mistake typo). 

Inside a fresh linux miniconda docker container:
```
git clone https://github.com/MetaSUB-CAMP/camp_short-read-taxonomy.git
cd camp_short-read-taxonomy/
conda env create -f configs/conda/short-read-taxonomy.yaml
```
Returns:
```
Collecting package metadata (repodata.json): done
Solving environment: failed

ResolvePackageNotFound:
  - click_default_group
```