### PR TITLE
Fix: update MetaPhlAn v4.2.2 flags, add Kraken2 memory-mapping and final report concatenation fixes

### DIFF
--- a/configs/parameters.yaml
+++ b/configs/parameters.yaml
@@ -21,6 +21,10 @@ metaphlan_database: ''
 
 
 # --- kraken2/bracken --- #
-
+# Use "--memory-mapping" when the Kraken2 database is very large or available RAM is limited.
+# This option reads the database directly from disk instead of loading it entirely into memory,
+# which significantly reduces RAM usage but may slightly slow down execution.
+# If not needed, leave the field empty as: ""
 kraken_bracken_database: ''
 read_len: 150
+kraken2_extra_args: "--memory-mapping"

--- a/setup.sh
+++ b/setup.sh
@@ -89,7 +89,8 @@ ask_taxonomy_db() {
 
                             if [[ "$TOOL_NAME" == "MetaPhlAn" ]]; then
                                 conda activate metaphlan
-                                metaphlan --install --bowtie2db $INSTALL_DIR
+                                INDEX_NAME="mpa_vJan25_CHOCOPhlAnSGB_202503"
+                                metaphlan --install -x "$INDEX_NAME" --db_dir "$INSTALL_DIR"
                                 DB_PATH="$INSTALL_DIR/mpa_vJan25_CHOCOPhlAnSGB_202503"
                                 conda deactivate
                             elif [[ "$TOOL_NAME" == "Kraken2" ]]; then

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -202,11 +202,12 @@ rule kraken2:
 	params:
 		out_dir = join(dirs.OUT, '2_kraken2', 'raw_kraken', '{sample}'),
 		database = config['kraken_bracken_database'],
+                extra = config.get('kraken2_extra_args', '')
 	shell:
 		"""
 		rm -r {params.out_dir}
 		mkdir -p {params.out_dir}
-		kraken2 --db {params.database} --threads {threads} --report {output.kreport} --output {output.kraken} --paired {input} > {log} 2>&1
+		kraken2 {params.extra} --db {params.database} --threads {threads} --report {output.kreport} --output {output.kraken} --paired {input} > {log} 2>&1
 		"""	
 
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -110,9 +110,9 @@ rule metaphlan:
 	shell:
 		"""
 		metaphlan --nproc {threads} -t rel_ab_w_read_stats --force \
-			--bowtie2db {params.database} \
-			--bowtie2out {params.prefix}.bowtie2.bz2 \
-			-o {output.report} --samout {output.sam} \
+			--db_dir {params.database} \
+			--mapout {params.prefix}.bowtie2.bz2 \
+			-o {output.report} -s {output.sam} \
 			--input_type fastq $(echo {input} | sed 's/ /,/g') > {log} 2>&1
 		"""
 

--- a/workflow/utils.py
+++ b/workflow/utils.py
@@ -228,27 +228,49 @@ def standardize_xtree(fi, out_dir, ncbi_taxid, uthresh):
 
 
 def concat_tbls(sample_lst, fo):
-    s_lst = []
-    tmp_colnames = []
-    sample_names = []
+    # Case 1: only one file → just copy it directly
     if len(sample_lst) == 1:
         shutil.copy(sample_lst[0], fo)
-    else:
-        for i,s in enumerate(sample_lst):
-            df = pd.read_csv(s, header = 0)
-            s_lst.append(df)
-            sample = df.columns[-1]
-            sample_names.append(sample)
-            if i < len(sample_lst) - 1:
-                tmp_colnames.extend(['tmp', 'tmp', 'tmp', sample])
-            else:
-                tmp_colnames.extend(df.columns)
-        df = pd.concat(s_lst, axis = 1, join = 'outer')
-        df.columns = tmp_colnames
-        df.drop(columns = 'tmp', axis = 1, inplace = True) # Get rid of all but the last set of 'classifier, clade, tax_id'
-        df = df[['classifier', 'clade', 'tax_id'] + sample_names]
-        df.fillna(0)
-        df.to_csv(fo, header = True, index = False)
+        return
+
+    merged = None
+    sample_cols = []
+
+    for path in sample_lst:
+        df = pd.read_csv(path, header=0)
+
+        # The last column contains the sample name
+        sample = df.columns[-1]
+        sample_cols.append(sample)
+
+        # Normalize key fields to avoid mismatches due to extra spaces
+        df['classifier'] = df['classifier'].astype(str).str.strip()
+        df['clade']      = df['clade'].astype(str).str.strip()
+        df['tax_id']     = df['tax_id'].astype(str).str.strip()
+
+        # Keep only the relevant columns
+        df = df[['classifier', 'clade', 'tax_id', sample]]
+
+        # If there are duplicate taxa within the same file, sum their values
+        df = df.groupby(['classifier','clade','tax_id'], as_index=False).sum(numeric_only=True)
+
+        # For the first file, initialize the merged table; 
+        # for the next files, perform an outer merge on taxonomic keys
+        if merged is None:
+            merged = df
+        else:
+            merged = pd.merge(
+                merged, df,
+                on=['classifier','clade','tax_id'],
+                how='outer'
+            )
+
+    # Replace any missing abundance values with 0 for each sample column
+    for c in sample_cols:
+        merged[c] = pd.to_numeric(merged[c], errors='coerce').fillna(0)
+
+    # Save the merged table
+    merged.to_csv(fo, index=False)
 
 
 def extract_unclassified_names(fi, fo):


### PR DESCRIPTION
### 1-This PR updates MetaPhlAn integration for v4.2.2 compatibility:

- Snakefile: replace deprecated flags `--bowtie2db` → `--db_dir`, `--bowtie2out` → `--mapout`, `--samout` → `-s`. 
- setup.sh: use `metaphlan --install -x mpa_vJan25_CHOCOPhlAnSGB_202503 --db_dir <path>` instead of `--bowtie2db`.

Context: running the test pipeline with MetaPhlAn v4.2.2 (installed via setup.sh) failed with `unrecognized arguments: --bowtie2db --bowtie2out --samout`. After these changes the test completes successfully and outputs the expected CSV/TSV reports.

Tested on an HPC environment (1 node, 16 cores, 40 GB RAM).

### 2- November 2025 Updates — Kraken2 and Abundance Table Concatenation

This pull request extends the previous MetaPhlAn v4.2.2 update by introducing two main improvements to the **taxonomy module**.


### 2.1  Add support for Kraken2 memory mapping

Added a new configuration parameter and corresponding update to the `kraken2` rule in the Snakefile to allow the use of `--memory-mapping` for large databases or limited RAM environments.

**Changes:**
- **Snakefile:** updated `kraken2` rule to include an optional `extra` parameter retrieved from `config.get('kraken2_extra_args', '')`, appended to the `kraken2` command.
- **configs/parameters.yaml:** added a new key `kraken2_extra_args` that allows users to specify additional Kraken2 options (e.g. `"--memory-mapping"`).

**Example:**
```

# --- kraken2/bracken --- #
# Use "--memory-mapping" when the Kraken2 database is very large or available RAM is limited.
kraken_bracken_database: '/lunarc/nobackup/projects/snic2019-34-3/Daria/core_nt_Database'
read_len: 100
kraken2_extra_args: "--memory-mapping"

```

This update improves flexibility and enables running Kraken2 with large databases efficiently by reducing peak memory usage.

### 2.2 Fix concatenation of per-sample relative abundance tables

Rewrote the concat_tbls() function in utils.py to ensure accurate merging of Bracken output tables across multiple samples.

Key improvements:
- Normalizes taxonomic keys (classifier, clade, tax_id) to avoid mismatches caused by extra spaces.
- Sums duplicate taxa within each file before merging.
- Performs an outer merge across all samples, ensuring that all taxa are retained.
- Fills missing values with 0 instead of leaving NaNs.
- Produces fully aligned, complete abundance matrices across all samples.

This fix resolves previous issues where taxa misalignment or missing values occurred during table concatenation.

